### PR TITLE
setup.py: remove six requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,4 @@ setup(name='jtextfsm',
           'License :: OSI Approved :: Apache Software License',
           'Operating System :: OS Independent',
           'Topic :: Software Development :: Libraries'],
-      requires=['six'],
       py_modules=['jtextfsm'])


### PR DESCRIPTION
six is not used at all. Not needed.